### PR TITLE
Support Tensorflow 2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # CapsNet-Keras
 [![License](https://img.shields.io/github/license/mashape/apistatus.svg?maxAge=2592000)](https://github.com/XifengGuo/CapsNet-Keras/blob/master/LICENSE)
 
-A Keras implementation of CapsNet in the paper:   
+A Keras/TensorFlow2.2 implementation of CapsNet in the paper:   
 [Sara Sabour, Nicholas Frosst, Geoffrey E Hinton. Dynamic Routing Between Capsules. NIPS 2017](https://arxiv.org/abs/1710.09829)   
 The current `average test error = 0.34%` and `best test error = 0.30%`.   
  
@@ -28,11 +28,9 @@ Open an issue or contact me with E-mail `guoxifeng1990@163.com` or WeChat `wenlo
 ## Usage
 
 **Step 1.
-Install [Keras>=2.0.7](https://github.com/fchollet/keras) 
-with [TensorFlow>=1.2](https://github.com/tensorflow/tensorflow) backend.**
+Install [TensorFlow>=2.0](https://github.com/tensorflow/tensorflow) backend.**
 ```
-pip install tensorflow-gpu
-pip install keras
+pip install tensorflow==2.2.0
 ```
 
 **Step 2. Clone this repository to local.**

--- a/capsulelayers.py
+++ b/capsulelayers.py
@@ -7,9 +7,9 @@ uncommenting them and commenting their counterparts.
 Author: Xifeng Guo, E-mail: `guoxifeng1990@163.com`, Github: `https://github.com/XifengGuo/CapsNet-Keras`
 """
 
-import keras.backend as K
 import tensorflow as tf
-from keras import initializers, layers
+import tensorflow.keras.backend as K
+from tensorflow.keras import initializers, layers
 
 
 class Length(layers.Layer):
@@ -20,7 +20,7 @@ class Length(layers.Layer):
     output: shape=[None, num_vectors]
     """
     def call(self, inputs, **kwargs):
-        return K.sqrt(K.sum(K.square(inputs), -1) + K.epsilon())
+        return tf.sqrt(tf.reduce_sum(tf.square(inputs), -1) + K.epsilon())
 
     def compute_output_shape(self, input_shape):
         return input_shape[:-1]
@@ -50,15 +50,15 @@ class Mask(layers.Layer):
             inputs, mask = inputs
         else:  # if no true label, mask by the max length of capsules. Mainly used for prediction
             # compute lengths of capsules
-            x = K.sqrt(K.sum(K.square(inputs), -1))
+            x = tf.sqrt(tf.reduce_sum(tf.square(inputs), -1))
             # generate the mask which is a one-hot code.
             # mask.shape=[None, n_classes]=[None, num_capsule]
-            mask = K.one_hot(indices=K.argmax(x, 1), num_classes=x.get_shape().as_list()[1])
+            mask = tf.one_hot(indices=tf.argmax(x, 1), depth=x.shape[1])
 
         # inputs.shape=[None, num_capsule, dim_capsule]
         # mask.shape=[None, num_capsule]
         # masked.shape=[None, num_capsule * dim_capsule]
-        masked = K.batch_flatten(inputs * K.expand_dims(mask, -1))
+        masked = K.batch_flatten(inputs * tf.expand_dims(mask, -1))
         return masked
 
     def compute_output_shape(self, input_shape):
@@ -79,18 +79,18 @@ def squash(vectors, axis=-1):
     :param axis: the axis to squash
     :return: a Tensor with same shape as input vectors
     """
-    s_squared_norm = K.sum(K.square(vectors), axis, keepdims=True)
-    scale = s_squared_norm / (1 + s_squared_norm) / K.sqrt(s_squared_norm + K.epsilon())
+    s_squared_norm = tf.reduce_sum(tf.square(vectors), axis, keepdims=True)
+    scale = s_squared_norm / (1 + s_squared_norm) / tf.sqrt(s_squared_norm + K.epsilon())
     return scale * vectors
 
 
 class CapsuleLayer(layers.Layer):
     """
-    The capsule layer. It is similar to Dense layer. Dense layer has `in_num` inputs, each is a scalar, the output of the 
+    The capsule layer. It is similar to Dense layer. Dense layer has `in_num` inputs, each is a scalar, the output of the
     neuron from the former layer, and it has `out_num` output neurons. CapsuleLayer just expand the output of the neuron
     from scalar to vector. So its input shape = [None, input_num_capsule, input_dim_capsule] and output shape = \
     [None, num_capsule, dim_capsule]. For Dense Layer, input_dim_capsule = dim_capsule = 1.
-    
+
     :param num_capsule: number of capsules in this layer
     :param dim_capsule: dimension of the output vectors of the capsules in this layer
     :param routings: number of iterations for the routing algorithm
@@ -109,7 +109,7 @@ class CapsuleLayer(layers.Layer):
         self.input_num_capsule = input_shape[1]
         self.input_dim_capsule = input_shape[2]
 
-        # Transform matrix
+        # Transform matrix, from each input capsule to each output capsule, there's a unique weight as in Dense layer.
         self.W = self.add_weight(shape=[self.num_capsule, self.input_num_capsule,
                                         self.dim_capsule, self.input_dim_capsule],
                                  initializer=self.kernel_initializer,
@@ -119,48 +119,48 @@ class CapsuleLayer(layers.Layer):
 
     def call(self, inputs, training=None):
         # inputs.shape=[None, input_num_capsule, input_dim_capsule]
-        # inputs_expand.shape=[None, 1, input_num_capsule, input_dim_capsule]
-        inputs_expand = K.expand_dims(inputs, 1)
+        # inputs_expand.shape=[None, 1, input_num_capsule, input_dim_capsule, 1]
+        inputs_expand = tf.expand_dims(tf.expand_dims(inputs, 1), -1)
 
         # Replicate num_capsule dimension to prepare being multiplied by W
-        # inputs_tiled.shape=[None, num_capsule, input_num_capsule, input_dim_capsule]
-        inputs_tiled = K.tile(inputs_expand, [1, self.num_capsule, 1, 1])
+        # inputs_tiled.shape=[None, num_capsule, input_num_capsule, input_dim_capsule, 1]
+        inputs_tiled = tf.tile(inputs_expand, [1, self.num_capsule, 1, 1, 1])
 
         # Compute `inputs * W` by scanning inputs_tiled on dimension 0.
-        # x.shape=[num_capsule, input_num_capsule, input_dim_capsule]
         # W.shape=[num_capsule, input_num_capsule, dim_capsule, input_dim_capsule]
-        # Regard the first two dimensions as `batch` dimension,
-        # then matmul: [input_dim_capsule] x [dim_capsule, input_dim_capsule]^T -> [dim_capsule].
+        # x.shape=[num_capsule, input_num_capsule, input_dim_capsule, 1]
+        # Regard the first two dimensions as `batch` dimension, then
+        # matmul(W, x): [..., dim_capsule, input_dim_capsule] x [..., input_dim_capsule, 1] -> [..., dim_capsule, 1].
         # inputs_hat.shape = [None, num_capsule, input_num_capsule, dim_capsule]
-        inputs_hat = K.map_fn(lambda x: K.batch_dot(x, self.W, [2, 3]), elems=inputs_tiled)
+        inputs_hat = tf.squeeze(tf.map_fn(lambda x: tf.matmul(self.W, x), elems=inputs_tiled))
 
         # Begin: Routing algorithm ---------------------------------------------------------------------#
         # The prior for coupling coefficient, initialized as zeros.
-        # b.shape = [None, self.num_capsule, self.input_num_capsule].
-        b = tf.zeros(shape=[K.shape(inputs_hat)[0], self.num_capsule, self.input_num_capsule])
+        # b.shape = [None, self.num_capsule, 1, self.input_num_capsule].
+        b = tf.zeros(shape=[inputs.shape[0], self.num_capsule, 1, self.input_num_capsule])
 
         assert self.routings > 0, 'The routings should be > 0.'
         for i in range(self.routings):
-            # c.shape=[batch_size, num_capsule, input_num_capsule]
-            c = tf.nn.softmax(b, dim=1)
+            # c.shape=[batch_size, num_capsule, 1, input_num_capsule]
+            c = tf.nn.softmax(b, axis=1)
 
-            # c.shape =  [batch_size, num_capsule, input_num_capsule]
+            # c.shape = [batch_size, num_capsule, 1, input_num_capsule]
             # inputs_hat.shape=[None, num_capsule, input_num_capsule, dim_capsule]
             # The first two dimensions as `batch` dimension,
-            # then matmal: [input_num_capsule] x [input_num_capsule, dim_capsule] -> [dim_capsule].
-            # outputs.shape=[None, num_capsule, dim_capsule]
-            outputs = squash(K.batch_dot(c, inputs_hat, [2, 2]))  # [None, 10, 16]
+            # then matmal: [..., 1, input_num_capsule] x [..., input_num_capsule, dim_capsule] -> [..., 1, dim_capsule].
+            # outputs.shape=[None, num_capsule, 1, dim_capsule]
+            outputs = squash(tf.matmul(c, inputs_hat))  # [None, 10, 1, 16]
 
             if i < self.routings - 1:
-                # outputs.shape =  [None, num_capsule, dim_capsule]
+                # outputs.shape =  [None, num_capsule, 1, dim_capsule]
                 # inputs_hat.shape=[None, num_capsule, input_num_capsule, dim_capsule]
-                # The first two dimensions as `batch` dimension,
-                # then matmal: [dim_capsule] x [input_num_capsule, dim_capsule]^T -> [input_num_capsule].
-                # b.shape=[batch_size, num_capsule, input_num_capsule]
-                b += K.batch_dot(outputs, inputs_hat, [2, 3])
+                # The first two dimensions as `batch` dimension, then
+                # matmal:[..., 1, dim_capsule] x [..., input_num_capsule, dim_capsule]^T -> [..., 1, input_num_capsule].
+                # b.shape=[batch_size, num_capsule, 1, input_num_capsule]
+                b += tf.matmul(outputs, inputs_hat, transpose_b=True)
         # End: Routing algorithm -----------------------------------------------------------------------#
 
-        return outputs
+        return tf.squeeze(outputs)
 
     def compute_output_shape(self, input_shape):
         return tuple([None, self.num_capsule, self.dim_capsule])


### PR DESCRIPTION
1. Change `keras` to `tf.keras`
2. Change `K.*` to `tf.*`. In TensorFlow 2, they actually call the same lower-level functions.
3. Change `K.batch_dot` to `tf.matmul` in class CapsuleLayer. The batch_dot changed its behavior in version 2.3 (or earlier). But I find `tf.matmul` is sufficient to implement the class CapsuleLayer.